### PR TITLE
Add dotenv require_keys to the app, add error handling for .env vars

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+# use dotenv to manage application keys - url, username, token
+# Dotenv.require_keys will raise an error if the specified keys cannot be found
 require 'dotenv'
 Dotenv.load('.env')
+Dotenv.require_keys('API_URL', 'API_TOKEN', 'API_USERNAME')
 
 # Load in environment variables for the api
 # so that all the tests can access these values

--- a/src/app.rb
+++ b/src/app.rb
@@ -1,7 +1,18 @@
 require 'dotenv'
 require_relative './Application/application'
 
-Dotenv.load('../.env')
+# check that environment variables have been properly loaded
+# warn the user if that is not the case
+begin
+  Dotenv.load('../.env')
+  Dotenv.require_keys('API_URL', 'API_TOKEN', 'API_USERNAME')
+rescue Dotenv::MissingKeys => e
+  puts
+  puts "\t *** Warning ***"
+  puts 'Key/s are missing from your .env file.'
+  puts e.to_s
+  puts
+end
 
 # Load in application secrets / details from .env file
 # These secrets should only be kept locally and not committed to source control


### PR DESCRIPTION
Used the Dotenv.require_keys method to ensure that the .env file has been correctly setup.
Added basic error handling to the application if this requirement is not met.